### PR TITLE
parser rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ license = "Unlicense"
 description = "Library to parse the Victron Energy VE.Direct protocol and map the data to useful structs with clear units"
 repository = "https://github.com/dbr/vedirect-rs/"
 readme = "README.md"
-keywords = ["solar", "serial", "parser"]
+keywords = ["solar", "serial", "parser", "vedirect"]
 
 [dependencies]
-nom = "5.1"
 thiserror = "1.0"
+strum = "0.24"
+strum_macros = "0.24"
 
 [dev-dependencies]
-serial = "0.4"
+serialport = { version = "4.1", default-features = false }
 anyhow = "1.0"

--- a/examples/read_serial.rs
+++ b/examples/read_serial.rs
@@ -15,7 +15,7 @@ pub fn record(port: &mut dyn SerialPort) -> anyhow::Result<()> {
         let r = port.read(&mut buf)?;
         let (p, _remainder) = vedirect::parse(&buf)?;
         println!("Got data: {:#?}", &p);
-        let mapped = vedirect::map_fields(&p)?;
+        let mapped = vedirect::map_fields_bmv700(&p)?;
         println!("Mapped data {:#?}", &mapped);
         std::thread::sleep(std::time::Duration::from_millis(100));
     }

--- a/examples/read_serial.rs
+++ b/examples/read_serial.rs
@@ -1,28 +1,35 @@
-// serial = "0.4"
+// serialport = "4.1"
 
-extern crate serial;
-use serial::SerialPort;
+use serialport::SerialPort;
+use vedirect::{Events, VEError};
 
-pub fn record(port: &mut dyn SerialPort) -> anyhow::Result<()> {
-    port.reconfigure(&|settings| {
-        settings.set_baud_rate(serial::Baud19200)?;
-        settings.set_char_size(serial::Bits8);
-        Ok(())
-    })?;
-    port.set_timeout(std::time::Duration::from_secs(2))?;
-    let mut buf: [u8; 1024] = [0; 1024];
+struct Listener;
+
+impl Events<vedirect::Bmv700> for Listener {
+    fn on_complete_block(&mut self, block: vedirect::Bmv700) {
+        println!("Mapped data {:#?}", &block);
+    }
+
+    fn on_parse_error(&mut self, _error: VEError, _parse_buf: &Vec<u8>) {}
+}
+
+pub fn record(mut port: Box<dyn SerialPort>) -> anyhow::Result<()> {
+    let mut buf: Vec<u8> = vec![0; 1024];
+    let mut listener = Listener{};
+    let mut parser = vedirect::Parser::new(& mut listener);
     loop {
-        let r = port.read(&mut buf)?;
-        let (p, _remainder) = vedirect::parse(&buf)?;
-        println!("Got data: {:#?}", &p);
-        let mapped = vedirect::map_fields_bmv700(&p)?;
-        println!("Mapped data {:#?}", &mapped);
+        let r = port.read(buf.as_mut_slice())?;
+        parser.feed(&buf[..r]).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut port = serial::open("/dev/ttyUSB1").expect("Failed to open serial port");
-    record(&mut port)?;
+    let port = serialport::new("/dev/ttyUSB1", 19_200)
+        .data_bits(serialport::DataBits::Eight)
+        .timeout(core::time::Duration::from_secs(2))
+        .open()
+        .expect("Failed to open vedirect serial port");
+    record(port)?;
     Ok(())
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,6 @@
-use std::collections::hash_map::HashMap;
+use std::{collections::hash_map::HashMap, str::from_utf8};
+
+use strum_macros::FromRepr;
 
 use crate::VEError;
 
@@ -6,7 +8,9 @@ use crate::VEError;
 type Watt = i32;
 type Percent = f32;
 type Volt = f32;
+type Ampere = f32;
 type Minute = i32;
+type KiloWattHours = i32;
 
 // Type conversion errors
 impl From<std::num::ParseIntError> for VEError {
@@ -19,6 +23,76 @@ impl From<std::num::ParseFloatError> for VEError {
     fn from(src: std::num::ParseFloatError) -> VEError {
         VEError::Parse(format!("Error parsing float: {}", src))
     }
+}
+
+#[derive(FromRepr, PartialEq, Eq, Debug)]
+pub enum OffReason {
+    None = 0x0,
+    NoInputPower = 0x00000001,
+    SwitchedOffPowerSwitch = 0x00000002,
+    SwitchedOffDMR = 0x00000004,
+    RemoteInput = 0x00000008,
+    ProtectionActive = 0x000000010,
+    Paygo = 0x00000020,
+    BMS = 0x000000040,
+    EngineShutdownDetection = 0x00000080,
+    AnalysingInputVoltage = 0x000000100,
+}
+
+#[derive(FromRepr, PartialEq, Eq, Debug)]
+pub enum TrackerOperationMode {
+    Off = 0,
+    VoltageOrCurrentLimited = 1,
+    MPPTrackerActive = 2,
+}
+
+#[derive(FromRepr, PartialEq, Eq, Debug)]
+pub enum ErrorCode {
+    NoError = 0,
+    BatteryVoltageTooHigh = 2,
+    ChargerTemperatureTooHigh = 17,
+    ChargerOverCurrent = 18,
+    ChargerCurrentReversed = 19,
+    BulkTimeLimitExceeded = 20,
+    CurrentSensorIssue = 21,
+    TerminalsOverheatd = 26,
+    ConverterIssue = 28,
+    InputVoltageTooHigh = 33,
+    InputCurrentTooHigh = 34,
+    InputShutdownBatVoltage = 38,
+    InputShutdownCurrentFlow = 39,
+    LostComWithDevices = 65,
+    SynchronisedChargingIssue = 66,
+    BMSConnectionLost = 67,
+    NetworkMisconfigured = 68,
+    FactoryCalibrationDataLost = 116,
+    InvalidFirmware = 117,
+    UserSettingsInvalid = 119,
+}
+
+#[derive(FromRepr, PartialEq, Eq, Debug)]
+pub enum StateOfOperation {
+    Off = 0,
+    LowPower = 1,
+    Fault = 2,
+    Bulk = 3,
+    Absorption = 4,
+    Float = 5,
+    Storage = 6,
+    Equalize = 7,
+    Inverting = 9,
+    PowerSupply = 11,
+    StartingUp = 245,
+    RepeatedAbsorption = 246,
+    AutoEqualize = 247,
+    BatterySafe = 248,
+    ExternalControl = 252,
+}
+
+pub trait VEDirectData {
+    fn fill(fields: &HashMap<String, Vec<u8>>) -> Result<Self, VEError>
+    where
+        Self: Sized;
 }
 
 /// Data for BMV 600 battery monitor series
@@ -52,8 +126,73 @@ pub struct Bmv700 {
     pub ttg: Minute,
 }
 
+impl VEDirectData for Bmv700 {
+    fn fill(fields: &HashMap<String, Vec<u8>>) -> Result<Self, VEError> {
+        Ok(Bmv700 {
+            voltage: convert_volt(fields, "V", 10.0)?,
+            power: convert_watt(fields, "P")?,
+            consumed: Some(convert_string(fields, "CE")?),
+            soc: convert_percentage(fields, "SOC")?,
+            ttg: convert_ttg(fields, "TTG")?,
+        })
+    }
+}
+
 /// Data for all MPPT solar charge controller
-// struct MPPT {}
+#[derive(Debug)]
+pub struct MPPT {
+    pub channel1_voltage: Volt,
+    pub panel_voltage: Volt,
+    pub panel_power: Watt,
+    pub battery_current: Ampere,
+    pub load_current: Ampere,
+    pub load_output_state: bool,
+    pub relay_state: Option<bool>,
+    pub off_reason: OffReason,
+    pub yield_total: KiloWattHours,
+    pub yield_today: KiloWattHours,
+    pub max_power_today: Watt,
+    pub yield_yesterday: KiloWattHours,
+    pub max_power_yesterday: Watt,
+    pub error_code: ErrorCode,
+    pub state_of_operation: StateOfOperation,
+    pub firmware: u16,
+    pub product_id: String,
+    pub serial_number: String,
+    pub day_sequence: u16,
+    pub tracker_mode: TrackerOperationMode,
+}
+
+impl VEDirectData for MPPT {
+    fn fill(fields: &HashMap<String, Vec<u8>>) -> Result<Self, VEError> {
+        Ok(MPPT {
+            channel1_voltage: convert_volt(fields, "V", 1000.0)?,
+            panel_voltage: convert_volt(fields, "VPV", 1000.0)?,
+            panel_power: convert_watt(fields, "PPV")?,
+            battery_current: convert_ampere(fields, "I", 1000.0)?,
+            load_current: convert_ampere(fields, "IL", 1000.0)?,
+            load_output_state: convert_bool(fields, "LOAD")?,
+            relay_state: if fields.contains_key("Relay") {
+                Some(convert_bool(fields, "Relay")?)
+            } else {
+                None
+            },
+            off_reason: convert_off_reason(fields, "OR")?,
+            yield_total: convert_watt(fields, "H19")?,
+            yield_today: convert_watt(fields, "H20")?,
+            max_power_today: convert_watt(fields, "H21")?,
+            yield_yesterday: convert_watt(fields, "H22")?,
+            max_power_yesterday: convert_watt(fields, "H23")?,
+            error_code: convert_error_code(fields, "ERR")?,
+            state_of_operation: convert_state_of_operation(fields, "CS")?,
+            firmware: convert_u16(fields, "FW")?,
+            product_id: convert_string(fields, "PID")?,
+            serial_number: convert_string(fields, "SER#")?,
+            day_sequence: convert_u16(fields, "HSDS")?,
+            tracker_mode: convert_tracker_mode(fields, "MPPT")?,
+        })
+    }
+}
 
 /// Data for Phoenix Inverters
 // struct PhoenixInverter {}
@@ -65,67 +204,205 @@ pub struct Bmv700 {
 // pub struct Everything {}
 
 /// "When the BMV is not synchronised, these statistics have no meaning, so "---" will be sent instead of a value"
-fn convert_percentage(rawkeys: &HashMap<&str, &str>, label: &str) -> Result<Option<Percent>, VEError> {
-    let raw = *(*rawkeys).get(label).ok_or(VEError::MissingField(label.into()))?;
+fn convert_percentage(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+) -> Result<Option<Percent>, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
 
-    if raw == "---" {
+    let s = from_utf8(&raw).expect("invalid str value");
+    if s == "---" {
         Ok(None)
     } else {
-        Ok(Some(raw.parse::<Percent>()? / 10.0))
+        Ok(Some(s.parse::<Percent>()? / 10.0))
     }
 }
 
-fn convert_volt(rawkeys: &HashMap<&str, &str>, label: &str) -> Result<Volt, VEError> {
-    let raw = (*rawkeys).get(label).ok_or(VEError::MissingField(label.into()))?;
-    let cleaned = raw.parse::<Volt>()? / 10.0;
+fn convert_volt(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+    factor: f32,
+) -> Result<Volt, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(raw).unwrap().parse::<Volt>()? / factor;
     Ok(cleaned)
 }
 
-fn convert_watt(rawkeys: &HashMap<&str, &str>, label: &str) -> Result<Watt, VEError> {
-    let raw = (*rawkeys).get(label).ok_or(VEError::MissingField(label.into()))?;
-    let cleaned = raw.parse::<Watt>()?;
+fn convert_ampere(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+    factor: f32,
+) -> Result<Ampere, VEError> {
+    let raw = (*rawkeys)
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(raw).unwrap().parse::<Ampere>()? / factor;
     Ok(cleaned)
 }
 
-fn convert_string(rawkeys: &HashMap<&str, &str>, label: &str) -> Result<String, VEError> {
-    let raw = *(*rawkeys).get(label).ok_or(VEError::MissingField(label.into()))?;
-    Ok(raw.into())
-}
-
-fn convert_ttg(rawkeys: &HashMap<&str, &str>, label: &str) -> Result<Minute, VEError> {
-    let raw = *(*rawkeys).get(label).ok_or(VEError::MissingField(label.into()))?;
-    let cleaned = raw.parse::<Minute>()?;
+fn convert_watt(rawkeys: &HashMap<String, Vec<u8>>, label: &str) -> Result<Watt, VEError> {
+    let raw = (*rawkeys)
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(raw).unwrap().parse::<Watt>()?;
     Ok(cleaned)
 }
 
+fn convert_u16(rawkeys: &HashMap<String, Vec<u8>>, label: &str) -> Result<u16, VEError> {
+    let raw = (*rawkeys)
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(raw).unwrap().parse::<u16>()?;
+    Ok(cleaned)
+}
 
-/// Take a list of fields and creates an easier to use structure
-pub fn map_fields_bmv700(fields: &Vec<crate::parser::Field>) -> Result<Bmv700, VEError> {
-    // Convert from list into map
-    let mut hm: HashMap<&str, &str> = HashMap::new();
-    for f in fields {
-        hm.insert(f.key, f.value);
+fn convert_string(rawkeys: &HashMap<String, Vec<u8>>, label: &str) -> Result<String, VEError> {
+    let raw = &*rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    Ok(String::from_utf8(raw.clone()).unwrap())
+}
+
+fn convert_bool(rawkeys: &HashMap<String, Vec<u8>>, label: &str) -> Result<bool, VEError> {
+    let raw = &*rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let s = from_utf8(&raw).unwrap();
+    if s == "ON" {
+        Ok(true)
+    } else if s == "OFF" {
+        Ok(false)
+    } else {
+        Err(VEError::OnOffExpected(String::from(s)))
+    }
+}
+
+fn convert_ttg(rawkeys: &HashMap<String, Vec<u8>>, label: &str) -> Result<Minute, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(&raw).unwrap().parse::<Minute>()?;
+    Ok(cleaned)
+}
+
+fn convert_error_code(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+) -> Result<ErrorCode, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(&raw).unwrap().parse::<usize>()?;
+    Ok(ErrorCode::from_repr(cleaned).unwrap_or(ErrorCode::NoError))
+}
+
+fn convert_off_reason(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+) -> Result<OffReason, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(&raw).unwrap();
+    match cleaned {
+        "0x00000000" => Ok(OffReason::None),
+        "0x00000001" => Ok(OffReason::NoInputPower),
+        "0x00000002" => Ok(OffReason::SwitchedOffPowerSwitch),
+        "0x00000004" => Ok(OffReason::SwitchedOffDMR),
+        "0x00000008" => Ok(OffReason::RemoteInput),
+        "0x00000010" => Ok(OffReason::ProtectionActive),
+        "0x00000020" => Ok(OffReason::Paygo),
+        "0x00000040" => Ok(OffReason::BMS),
+        "0x00000080" => Ok(OffReason::EngineShutdownDetection),
+        "0x00000100" => Ok(OffReason::AnalysingInputVoltage),
+        _ => Err(VEError::UnknownCode(cleaned.to_string())),
+    }
+}
+
+fn convert_state_of_operation(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+) -> Result<StateOfOperation, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(&raw).unwrap().parse::<usize>()?;
+    Ok(StateOfOperation::from_repr(cleaned).unwrap_or(StateOfOperation::Off))
+}
+
+fn convert_tracker_mode(
+    rawkeys: &HashMap<String, Vec<u8>>,
+    label: &str,
+) -> Result<TrackerOperationMode, VEError> {
+    let raw = rawkeys
+        .get(label)
+        .ok_or(VEError::MissingField(label.into()))?;
+    let cleaned = from_utf8(&raw).unwrap().parse::<usize>()?;
+    Ok(TrackerOperationMode::from_repr(cleaned).unwrap_or(TrackerOperationMode::Off))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Events;
+
+    struct CheckerBmv700;
+
+    impl Events<Bmv700> for CheckerBmv700 {
+        fn on_complete_block(&mut self, data: Bmv700) {
+            assert_eq!(data.power, 123);
+            assert_eq!(data.consumed, Some("53".into()));
+            assert_eq!(data.soc, Some(45.2));
+            assert_eq!(data.ttg, 60);
+            assert_eq!(data.voltage, 23.2);
+        }
+
+        fn on_parse_error(&mut self, _error: VEError, _parse_buf: &Vec<u8>) {
+            assert!(false);
+        }
     }
 
-    Ok(Bmv700 {
-        voltage: convert_volt(&hm, "V")?,
-        power: convert_watt(&hm, "P")?,
-        consumed: Some(convert_string(&hm, "CE")?),
-        soc: convert_percentage(&hm, "SOC")?,
-        ttg: convert_ttg(&hm, "TTG")?,
-    })
-}
+    #[test]
+    fn test_mapping() {
+        let input = "\r\nP\t123\r\nCE\t53\r\nSOC\t452\r\nTTG\t60\r\nRelay\tOFF\r\nAlarm\tOFF\r\nV\t232\r\nChecksum\t12";
+        let mut checker = CheckerBmv700 {};
+        let mut parser = crate::Parser::new(&mut checker);
+        parser.feed(input.as_bytes()).unwrap();
+    }
 
-#[test]
-fn test_mapping() {
-    let (raw, remainder) = crate::parser::parse(
-        "\r\nP\t123\r\nCE\t53\r\nSOC\t452\r\nTTG\t60\r\nRelay\tOFF\r\nAlarm\tOFF\r\nV\t232\r\nChecksum\t12".as_bytes(),
-    )
-    .unwrap();
-    let data = map_fields_bmv700(&raw).unwrap();
-    assert_eq!(data.power, 123);
-    assert_eq!(data.consumed, Some("53".into()));
-    assert_eq!(data.soc, Some(45.2));
-    assert_eq!(data.ttg, 60);
-    assert_eq!(data.voltage, 23.2);
+    struct CheckerMPPT;
+
+    impl Events<MPPT> for CheckerMPPT {
+        fn on_complete_block(&mut self, data: MPPT) {
+            assert_eq!(data.channel1_voltage, 12.54);
+            assert_eq!(data.battery_current, 0.04);
+            assert_eq!(data.panel_voltage, 18.54);
+            assert_eq!(data.panel_power, 5);
+            assert_eq!(data.load_current, 0.3);
+            assert_eq!(data.load_output_state, true);
+            assert_eq!(data.yield_total, 144);
+            assert_eq!(data.yield_today, 1);
+            assert_eq!(data.yield_yesterday, 4);
+            assert_eq!(data.max_power_today, 6);
+            assert_eq!(data.max_power_yesterday, 14);
+            assert_eq!(data.day_sequence, 16);
+            assert_eq!(data.firmware, 159);
+            assert_eq!(data.tracker_mode, TrackerOperationMode::MPPTrackerActive);
+        }
+
+        fn on_parse_error(&mut self, _error: VEError, _parse_buf: &Vec<u8>) {
+            assert!(false);
+        }
+    }
+    #[test]
+    fn test_mapping_mppt() {
+        let input = "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY2KR\r\nV\t12540\r\nI\t40\r\nVPV\t18540\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nOR\t0x00000000\r\nERR\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHSDS\t16\r\nChecksum\t?";
+        let mut checker = CheckerMPPT {};
+        let mut parser = crate::Parser::new(&mut checker);
+        parser.feed(input.as_bytes()).unwrap();
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -100,7 +100,7 @@ fn convert_ttg(rawkeys: &HashMap<&str, &str>, label: &str) -> Result<Minute, VEE
 
 
 /// Take a list of fields and creates an easier to use structure
-pub fn map_fields(fields: &Vec<crate::parser::Field>) -> Result<Bmv700, VEError> {
+pub fn map_fields_bmv700(fields: &Vec<crate::parser::Field>) -> Result<Bmv700, VEError> {
     // Convert from list into map
     let mut hm: HashMap<&str, &str> = HashMap::new();
     for f in fields {
@@ -122,7 +122,7 @@ fn test_mapping() {
         "\r\nP\t123\r\nCE\t53\r\nSOC\t452\r\nTTG\t60\r\nRelay\tOFF\r\nAlarm\tOFF\r\nV\t232\r\nChecksum\t12".as_bytes(),
     )
     .unwrap();
-    let data = map_fields(&raw).unwrap();
+    let data = map_fields_bmv700(&raw).unwrap();
     assert_eq!(data.power, 123);
     assert_eq!(data.consumed, Some("53".into()));
     assert_eq!(data.soc, Some(45.2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ pub enum VEError {
 
 // Re-export
 pub use parser::parse;
-pub use data::map_fields;
+pub use data::map_fields_bmv700;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-mod parser;
 mod data;
+mod parser;
 
 use thiserror::Error;
 
@@ -16,8 +16,16 @@ pub enum VEError {
 
     #[error("missing field from recieved data")]
     MissingField(String),
+
+    #[error("ON or OFF value expected")]
+    OnOffExpected(String),
+
+    #[error("Unknown enum code")]
+    UnknownCode(String),
 }
 
 // Re-export
-pub use parser::parse;
-pub use data::map_fields_bmv700;
+pub use parser::Events;
+pub use parser::Parser;
+pub use data::Bmv700;
+pub use data::MPPT;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,121 +1,446 @@
-use crate::VEError;
+use std::{collections::HashMap, marker::PhantomData, str::from_utf8};
+
+use crate::{data, VEError};
 
 #[derive(Debug)]
-pub struct Field<'a> {
-    pub key: &'a str,
-    pub value: &'a str,
+pub struct VEField {
+    pub label: String,
+    pub value: Vec<u8>,
 }
 
-#[derive(Debug)]
-pub struct Checksum {
-    value: u8,
+pub struct Parser<'a, D: data::VEDirectData, E: Events<D>> {
+    first_parse: bool,
+    parse_buf: Vec<u8>,
+    fields: HashMap<String, Vec<u8>>,
+    listener: &'a mut E,
+    phanton: PhantomData<(&'a E, D)>,
 }
 
-/// Parse binary protocol using nom
-fn rawparse(data: &[u8]) -> nom::IResult<&[u8], (Vec<Field>, Checksum)> {
-    use nom::bytes::streaming::tag;
-    use nom::bytes::streaming::take_until;
-    use nom::character::streaming::alphanumeric1;
-    use nom::character::streaming::anychar;
-    use nom::character::streaming::char;
-    use nom::combinator::map;
-    use nom::combinator::not;
-    use nom::multi::many1;
-    use nom::sequence::pair;
-    use nom::sequence::preceded;
-    use nom::sequence::separated_pair;
-    use nom::IResult;
+pub trait Events<D: data::VEDirectData> {
+    fn on_complete_block(&mut self, _block: D) {}
+    fn on_missing_field(&mut self, _label: String) {}
+    fn on_mapping_error(&mut self, _error: VEError) {}
+    fn on_parse_error(&mut self, _error: VEError, _parse_buf: &Vec<u8>) {}
+}
 
-    /// Label which is not "Checksum"
-    fn field_label(input: &[u8]) -> IResult<&[u8], &str> {
-        map(
-            preceded(not(tag("Checksum")), alphanumeric1),
-            |s: &[u8]| std::str::from_utf8(s).expect("label"),
-        )(input)
+const CR: u8 = 13;
+const LF: u8 = 10;
+const TAB: u8 = 9;
+const COLON: u8 = 58;
+const A: u8 = 65;
+
+impl<'a, E: Events<D>, D: data::VEDirectData> Parser<'a, D, E> {
+    pub fn new(listener: &'a mut E) -> Self {
+        Parser {
+            first_parse: true,
+            parse_buf: Vec::new(),
+            fields: HashMap::new(),
+            listener,
+            phanton: PhantomData,
+        }
     }
-    fn line(input: &[u8]) -> IResult<&[u8], Field> {
-        // Each field starts with newline, then <field-label> <tab> <field-value>
-        let parsed = pair(
-            // Newline
-            tag("\r\n"),
-            // Field, tab, value
-            separated_pair(field_label, char('\t'), take_until("\r\n"))
+
+    fn parse_field(data: &[u8], read_pos: usize) -> Result<(VEField, usize), VEError> {
+        if read_pos + 1 >= data.len() {
+            return Err(VEError::NeedMoreData);
+        }
+
+        let mut cp = read_pos;
+
+        if data[cp] == CR && data[cp + 1] == LF {
+            cp = cp + 2;
+            match data[cp..].iter().position(|&c| c == TAB) {
+                Some(pos) => {
+                    let label = String::from_utf8((&data[cp..(cp + pos)]).to_vec())
+                        .expect("invalid label string");
+                    cp = cp + pos + 1; // +1 to skip TAB
+                    let endpos_res = data[cp..].iter().position(|&c| c == CR);
+                    match endpos_res {
+                        Some(endpos) => {
+                            let value = &data[cp..(cp + endpos)];
+                            Ok((
+                                VEField {
+                                    label,
+                                    value: value.to_vec(),
+                                },
+                                cp + endpos,
+                            ))
+                        }
+                        None => {
+                            if label == "Checksum" {
+                                let value = &data[cp..];
+                                Ok((
+                                    VEField {
+                                        label,
+                                        value: value.to_vec(),
+                                    },
+                                    data.len(),
+                                ))
+                            } else {
+                                Err(VEError::NeedMoreData)
+                            }
+                        }
+                    }
+                }
+                None => Err(VEError::NeedMoreData),
+            }
+        } else {
+            eprintln!("Illegal field start");
+            Err(VEError::Parse("Illegal field start".to_string()))
+        }
+    }
+
+    pub fn feed(&mut self, data: &[u8]) -> Result<(), VEError> {
+        if self.first_parse {
+            // skip to first field start as we might have started somewhere in the middle
+            match data.iter().position(|&c| c == CR) {
+                Some(pos) => self.parse_buf.extend_from_slice(&data[pos..]),
+                None => return Err(VEError::NeedMoreData),
+            }
+            self.first_parse = false;
+        } else {
+            self.parse_buf.extend(data);
+        }
+
+        let mut cp = 0;
+        loop {
+            // skip hex mode messages, those can periodically occur
+            while cp + 1 < self.parse_buf.len()
+                && self.parse_buf[cp] == COLON
+                && self.parse_buf[cp + 1] == A
+            {
+                match self.parse_buf[cp..].iter().position(|&c| c == LF) {
+                    Some(pos) => {
+                        eprintln!(
+                            "Hex-msg: {}",
+                            from_utf8(&self.parse_buf[cp..(cp + pos)]).unwrap()
+                        );
+                        if cp + pos + 1 < self.parse_buf.len() {
+                            cp = cp + pos + 1;
+                        } else {
+                            self.parse_buf.clear();
+                            return Ok(());
+                        }
+                    }
+                    None => return Ok(()),
+                }
+            }
+
+            // println!("parse: {}", from_utf8(&self.parse_buf[cp..]).unwrap());
+            match Parser::<D, E>::parse_field(&self.parse_buf, cp) {
+                Ok((field, read_pos)) => {
+                    cp = read_pos;
+                    if &field.label == "Checksum" {
+                        match D::fill(&self.fields) {
+                            Ok(mapped) => {
+                                self.listener.on_complete_block(mapped);
+                                // block_complete(mapped);
+                                self.fields.clear();
+                            }
+                            Err(VEError::MissingField(label)) => {
+                                // we didn't get all needed fields to map
+                                // reset and hope for more in the next block
+                                self.listener.on_missing_field(label);
+                                self.fields.clear(); // reset fields
+                                self.parse_buf.drain(0..cp);
+                                cp = 0;
+                            }
+                            Err(e) => self.listener.on_mapping_error(e),
+                        }
+                    } else {
+                        self.fields.insert(field.label, field.value);
+                    }
+                }
+                Err(VEError::NeedMoreData) => {
+                    let clear_range = if cp > self.parse_buf.len() {
+                        self.parse_buf.len()
+                    } else {
+                        cp
+                    };
+                    self.parse_buf.drain(0..clear_range);
+                    break;
+                }
+                Err(e) => {
+                    self.listener.on_parse_error(e, &self.parse_buf);
+                    self.parse_buf.clear();
+                    self.fields.clear(); // reset fields
+                    self.first_parse = true;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct CollectorBmv700 {
+        data: Vec<data::Bmv700>,
+    }
+
+    impl Events<data::Bmv700> for CollectorBmv700 {
+        fn on_complete_block(&mut self, block: data::Bmv700) {
+            self.data.push(block);
+            println!("Block complete");
+        }
+
+        fn on_parse_error(&mut self, _error: VEError, _parse_buf: &Vec<u8>) {
+            println!("parse error");
+        }
+    }
+
+    #[test]
+    fn test_partial_stream() {
+        let data = "\r\nH18\t2415\r\nChecksum\t\u{4}\r\nPID\t0xA381\r\nV\t12282\r\nVS\t29\r\nI\t-2288\r\nP\t-28\r\nCE\t-74900\r\nSOC\t916\r\nTTG\t10350\r\nAlarm\tOFF\r\nRelay\tOFF\r\nAR\t0\r\nBMV\t712 Smart\r\nFW\t0403\r\nChecksum\t~\r\nH1\t-76138\r\nH2\t-76138\r\nH3\t0\r\nH4\t0\r\nH5\t0\r\nH6\t-1876218\r\nH7\t12171\r\nH8\t20418\r\nH9\t1199744\r\nH10\t0\r\nH11\t0\r\nH12\t0\r\nH15\t20\r\nH16\t21033\r\nH17\t2404\r\nH18\t2415\r\nChecksum\t\u{3}\r\nPID\t0xA381\r\n".as_bytes();
+        // let mut alldata: Vec<data::Bmv700> = vec![];
+        let mut collector = CollectorBmv700 { data: vec![] };
+
+        let mut parser = Parser::new(&mut collector);
+        parser.feed(data).unwrap();
+
+        // Should have some data remaining
+        assert!(parser.parse_buf.len() > 0);
+        assert_eq!(parser.parse_buf.len(), 2);
+        // Got one block valid data
+        assert_eq!(collector.data.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_field() {
+        let data = "\r\nPID\t0xA053\r\nFW\t159\r\nChecksum\t?".as_bytes();
+
+        let (field, read_pos) =
+            Parser::<data::Bmv700, CollectorBmv700>::parse_field(data, 0).unwrap();
+        assert_eq!(field.label, "PID");
+        assert_eq!(field.value, "0xA053".as_bytes());
+        assert_eq!(read_pos, 12);
+
+        let (field, read_pos) =
+            Parser::<data::Bmv700, CollectorBmv700>::parse_field(data, 12).unwrap();
+        assert_eq!(field.label, "FW");
+        assert_eq!(field.value, "159".as_bytes());
+        assert_eq!(read_pos, 20);
+
+        assert_eq!(
+            Parser::<data::Bmv700, CollectorBmv700>::parse_field(data, 19)
+                .err()
+                .unwrap()
+                .to_string(),
+            "error parsing data".to_string()
         );
-        // Map data
-        let f = map(parsed, |(_nl, d)| Field {
-            key: (d.0),
-            value: std::str::from_utf8(d.1).expect("invalid string"),
-        })(input);
-        f
-    }
-    fn checksum(input: &[u8]) -> IResult<&[u8], Checksum> {
-        // "Checksum" <tab> <checksum byte>
-        let parsed = pair(
-            tag("\r\n"),
-            separated_pair(tag("Checksum"), char('\t'), anychar)
+
+        let (field, read_pos) =
+            Parser::<data::Bmv700, CollectorBmv700>::parse_field(data, 20).unwrap();
+        assert_eq!(field.label, "Checksum");
+        assert_eq!(read_pos, 32);
+
+        let data = "\r\nFW\t159".as_bytes();
+        assert_eq!(
+            Parser::<data::Bmv700, CollectorBmv700>::parse_field(data, 0)
+                .err()
+                .unwrap()
+                .to_string(),
+            "Need more data to parse successfully".to_string()
         );
-        map(parsed, |(_nl, d)| Checksum { value: d.1 as u8 })(input)
-    }
-    fn chunk(input: &[u8]) -> IResult<&[u8], (Vec<Field>, Checksum)> {
-        pair(many1(line), checksum)(input)
-    }
-    chunk(data)
-}
-
-pub fn parse(data: &[u8]) -> Result<(Vec<Field>, &[u8]), VEError> {
-    let (data, remainder) = match rawparse(data) {
-        Err(nom::Err::Error(e)) => Err(VEError::Parse(format!(
-            "Parse error: {:?} - remaining data: {:?}",
-            e.1,
-            std::str::from_utf8(e.0),
-        ))),
-        Err(nom::Err::Incomplete(_needed)) => Err(VEError::NeedMoreData),
-        Err(e) => Err(VEError::Parse(format!("Unknown error while parsing: {}", e))),
-        Ok((remainder, data)) => Ok((data, remainder)),
-    }?;
-    let (fields, checksum) = data;
-    println!("Checksum: {:?}\nFields: {:#?}", checksum, fields);
-    Ok((fields, &remainder))
-}
-
-#[test]
-fn test_parse_line() {
-    let data = "\r\nfield1\tvalue1\r\nfield2\tvalue2\r\nChecksum\t4".as_bytes();
-    println!("{:?}", data);
-    let (data, remaining) = parse(data).unwrap();
-    assert_eq!(data.len(), 2);
-    assert_eq!(data[0].key, "field1");
-    assert_eq!(data[0].value, "value1");
-    assert_eq!(data[1].key, "field2");
-    assert_eq!(data[1].value, "value2");
-}
-
-#[test]
-fn test_parse_nonsense() {
-    let data= "\r\n!!!!\t\tvalue1\r\nChecksum\t42".as_bytes();
-    assert!(parse(data).is_err());
-}
-
-#[test]
-fn test_partial_stream() {
-    let mut data = "\r\nH18\t2415\r\nChecksum\t\u{4}\r\nPID\t0xA381\r\nV\t12282\r\nVS\t29\r\nI\t-2288\r\nP\t-28\r\nCE\t-74900\r\nSOC\t916\r\nTTG\t10350\r\nAlarm\tOFF\r\nRelay\tOFF\r\nAR\t0\r\nBMV\t712 Smart\r\nFW\t0403\r\nChecksum\t~\r\nH1\t-76138\r\nH2\t-76138\r\nH3\t0\r\nH4\t0\r\nH5\t0\r\nH6\t-1876218\r\nH7\t12171\r\nH8\t20418\r\nH9\t1199744\r\nH10\t0\r\nH11\t0\r\nH12\t0\r\nH15\t20\r\nH16\t21033\r\nH17\t2404\r\nH18\t2415\r\nChecksum\t\u{3}\r\nPID\t0xA381\r\n".as_bytes();
-    let mut alldata: Vec<Vec<Field>> = vec![];
-    while data.len() > 0 {
-        let res = parse(&data);
-        match res {
-            Ok((parsed, remainder)) => {
-                alldata.push(parsed);
-                data = remainder;
-            },
-            Err(VEError::NeedMoreData) => {break;}
-            Err(e) => {panic!(e);}
-        };
     }
 
-    // Got three blocks of data
-    assert_eq!(alldata.len(), 3);
-    // Should have some data remaining
-    assert!(data.len() > 0);
-    assert_eq!(data.len(), 14);
-    assert!(false);
+    struct CollectorMPPT {
+        data: Vec<data::MPPT>,
+    }
+
+    impl Events<data::MPPT> for CollectorMPPT {
+        fn on_complete_block(&mut self, block: data::MPPT) {
+            self.data.push(block);
+        }
+
+        fn on_parse_error(&mut self, _error: VEError, _parse_buf: &Vec<u8>) {
+            println!("parse error");
+        }
+    }
+
+    #[test]
+    fn test_mppt_stream() {
+        let data = "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY2KR\r\nV\t12540\r\nI\t40\r\nVPV\t18540\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nOR\t0x00000000\r\nERR\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHSDS\t16\r\nChecksum\t?".as_bytes();
+
+        let mut collector = CollectorMPPT { data: vec![] };
+        let mut parser = Parser::new(&mut collector);
+        parser.feed(data).unwrap();
+        assert_eq!(collector.data.len(), 1);
+        let fields = &collector.data[0];
+        assert_eq!(fields.channel1_voltage, 12.54);
+        assert_eq!(fields.battery_current, 0.04);
+        assert_eq!(fields.panel_voltage, 18.54);
+        assert_eq!(fields.panel_power, 5);
+        assert_eq!(fields.load_current, 0.3);
+        assert_eq!(fields.load_output_state, true);
+        assert_eq!(fields.yield_total, 144);
+        assert_eq!(fields.yield_today, 1);
+        assert_eq!(fields.yield_yesterday, 4);
+        assert_eq!(fields.max_power_today, 6);
+        assert_eq!(fields.max_power_yesterday, 14);
+        assert_eq!(fields.day_sequence, 16);
+        assert_eq!(fields.firmware, 159);
+        assert_eq!(
+            fields.tracker_mode,
+            crate::data::TrackerOperationMode::MPPTrackerActive
+        );
+    }
+
+    #[test]
+    fn test_mppt_stream_partial() {
+        let datas = vec![
+        "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY",
+        "2KR\r\nV\t12540\r\nI\t40\r\nVPV\t18540\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nO",
+        "R\t0x00000000\r\nERR\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHS",
+        "DS\t16\r\nChecksum\t?",
+        "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY2KR\r\nV\t12",
+        "540\r\nI\t110\r\nVPV\t17660\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nOR\t0x00000000\r\nERR",
+        "\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHSDS\t16\r\nChecksum\t?",
+        ];
+
+        let mut collector = CollectorMPPT { data: vec![] };
+        let mut parser = Parser::new(&mut collector);
+        for data in datas {
+            parser.feed(data.as_bytes()).unwrap();
+        }
+        assert_eq!(collector.data.len(), 2);
+        let fields = &collector.data[0];
+        assert_eq!(fields.channel1_voltage, 12.54);
+        assert_eq!(fields.battery_current, 0.04);
+        assert_eq!(fields.panel_voltage, 18.54);
+        assert_eq!(fields.panel_power, 5);
+        assert_eq!(fields.load_current, 0.3);
+        assert_eq!(fields.load_output_state, true);
+        assert_eq!(fields.yield_total, 144);
+        assert_eq!(fields.yield_today, 1);
+        assert_eq!(fields.yield_yesterday, 4);
+        assert_eq!(fields.max_power_today, 6);
+        assert_eq!(fields.max_power_yesterday, 14);
+        assert_eq!(fields.day_sequence, 16);
+        assert_eq!(fields.firmware, 159);
+        assert_eq!(
+            fields.tracker_mode,
+            crate::data::TrackerOperationMode::MPPTrackerActive
+        );
+
+        let fields = &collector.data[1];
+        assert_eq!(fields.channel1_voltage, 12.54);
+        assert_eq!(fields.battery_current, 0.11);
+        assert_eq!(fields.panel_voltage, 17.66);
+        assert_eq!(fields.panel_power, 5);
+        assert_eq!(fields.load_current, 0.3);
+        assert_eq!(fields.load_output_state, true);
+        assert_eq!(fields.yield_total, 144);
+        assert_eq!(fields.yield_today, 1);
+        assert_eq!(fields.yield_yesterday, 4);
+        assert_eq!(fields.max_power_today, 6);
+        assert_eq!(fields.max_power_yesterday, 14);
+        assert_eq!(fields.day_sequence, 16);
+        assert_eq!(fields.firmware, 159);
+        assert_eq!(
+            fields.tracker_mode,
+            crate::data::TrackerOperationMode::MPPTrackerActive
+        );
+    }
+
+    #[test]
+    fn test_incomplete_block_reset() {
+        let datas = vec![
+        "2540\r\nI\t40\r\nVPV\t18540\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nO",
+        "R\t0x00000000\r\nERR\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHS",
+        "DS\t16\r\nChecksum\t?",
+        "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY2KR\r\nV\t12",
+        "540\r\nI\t110\r\nVPV\t17660\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nOR\t0x00000000\r\nERR",
+        "\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHSDS\t16\r\nChecksum\t?",
+    ];
+
+        let mut collector = CollectorMPPT { data: vec![] };
+        let mut parser = Parser::new(&mut collector);
+        for data in datas {
+            parser.feed(data.as_bytes()).unwrap();
+        }
+        assert_eq!(collector.data.len(), 1);
+
+        let fields = &collector.data[0];
+        assert_eq!(fields.channel1_voltage, 12.54);
+        assert_eq!(fields.battery_current, 0.11);
+        assert_eq!(fields.panel_voltage, 17.66);
+        assert_eq!(fields.panel_power, 5);
+        assert_eq!(fields.load_current, 0.3);
+        assert_eq!(fields.load_output_state, true);
+        assert_eq!(fields.yield_total, 144);
+        assert_eq!(fields.yield_today, 1);
+        assert_eq!(fields.yield_yesterday, 4);
+        assert_eq!(fields.max_power_today, 6);
+        assert_eq!(fields.max_power_yesterday, 14);
+        assert_eq!(fields.day_sequence, 16);
+        assert_eq!(fields.firmware, 159);
+        assert_eq!(
+            fields.tracker_mode,
+            crate::data::TrackerOperationMode::MPPTrackerActive
+        );
+    }
+
+    #[test]
+    fn test_mppt_stream_hex_messages() {
+        let datas = vec![
+        "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY",
+        "2KR\r\nV\t12540\r\nI\t40\r\nVPV\t18540\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nO",
+        "R\t0x00000000\r\nERR\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHS",
+        "DS\t16\r\nChecksum\t?",
+        ":A4F1000010000000000AD000000AD000000E508AE05139D04",
+        "FFFFFFFFFFFFFFFFFFFFFFFFFF4A\n",
+        ":A5010000002000000040000002405C60400000000002E01000000000E0000000A00BA071300D7\n",
+        "\r\nPID\t0xA053\r\nFW\t159\r\nSER#\tHQ2132QY2KR\r\nV\t12",
+        "540\r\nI\t110\r\nVPV\t17660\r\nPPV\t5\r\nCS\t3\r\nMPPT\t2\r\nOR\t0x00000000\r\nERR",
+        "\t0\r\nLOAD\tON\r\nIL\t300\r\nH19\t144\r\nH20\t1\r\nH21\t6\r\nH22\t4\r\nH23\t14\r\nHSDS\t16\r\nChecksum\t?",
+    ];
+
+        let mut collector = CollectorMPPT { data: vec![] };
+        let mut parser = Parser::new(&mut collector);
+        for data in datas {
+            parser.feed(data.as_bytes()).unwrap();
+        }
+        assert_eq!(collector.data.len(), 2);
+        let fields = &collector.data[0];
+        assert_eq!(fields.channel1_voltage, 12.54);
+        assert_eq!(fields.battery_current, 0.04);
+        assert_eq!(fields.panel_voltage, 18.54);
+        assert_eq!(fields.panel_power, 5);
+        assert_eq!(fields.load_current, 0.3);
+        assert_eq!(fields.load_output_state, true);
+        assert_eq!(fields.yield_total, 144);
+        assert_eq!(fields.yield_today, 1);
+        assert_eq!(fields.yield_yesterday, 4);
+        assert_eq!(fields.max_power_today, 6);
+        assert_eq!(fields.max_power_yesterday, 14);
+        assert_eq!(fields.day_sequence, 16);
+        assert_eq!(fields.firmware, 159);
+        assert_eq!(
+            fields.tracker_mode,
+            crate::data::TrackerOperationMode::MPPTrackerActive
+        );
+
+        let fields = &collector.data[1];
+        assert_eq!(fields.channel1_voltage, 12.54);
+        assert_eq!(fields.battery_current, 0.11);
+        assert_eq!(fields.panel_voltage, 17.66);
+        assert_eq!(fields.panel_power, 5);
+        assert_eq!(fields.load_current, 0.3);
+        assert_eq!(fields.load_output_state, true);
+        assert_eq!(fields.yield_total, 144);
+        assert_eq!(fields.yield_today, 1);
+        assert_eq!(fields.yield_yesterday, 4);
+        assert_eq!(fields.max_power_today, 6);
+        assert_eq!(fields.max_power_yesterday, 14);
+        assert_eq!(fields.day_sequence, 16);
+        assert_eq!(fields.firmware, 159);
+        assert_eq!(
+            fields.tracker_mode,
+            crate::data::TrackerOperationMode::MPPTrackerActive
+        );
+    }
 }


### PR DESCRIPTION
Hi!

I know this project didn't see any work in 2 years, but I needed a vedirect->prometheus solution.
And took this as a starting point, but for me the parser usage was very cumbersome
(having to handle parsing buffers on the user side,...)
So I basically rewrote the whole thing and it now supports also MPPT blocks and is easier to use(from a user point).
Also the new parser tries to ignore data errors and just keep parsing, as data is sent every second anyway.

It still doesn't support the HEX protocol, but it now ignores hex messages that are sent(on my MPPT) from time to time.